### PR TITLE
Fix slow response

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -37,7 +37,7 @@ module.exports = function initialize (adapter, opts) {
   }
 
   let maxResults = 100000
-  let chunkSize = 10
+  let chunkSize = 10000
   let resultSizeMax = 200
   if (process.env.MAX_ROWS_LEVELDB) {
     try {


### PR DESCRIPTION
chunkSize too small(10). Scan all block take n*M times. (M is average time to hit to leveldb)
Reduce n to help reduce response time
n = highestBlock / chunkSize